### PR TITLE
convert to ArgumentCheck to checkmate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .renviron
 .rprofile
 .rproj
-.Rproj
+*.Rproj
 .rproj.user
 .rhistory
 .rapp.history

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ LazyData: true
 Depends:
     R (>= 4.0)
 Imports:
-    ArgumentCheck,
+    checkmate,
     BiocParallel,
     data.table,
     DrImpute,

--- a/R/Helper.R
+++ b/R/Helper.R
@@ -21,39 +21,39 @@
 CreateArgCheck <- function(missing = NULL, match = NULL, acceptable = NULL,
     null = NULL) {
 
-    Check <- ArgumentCheck::newArgCheck()
-
+    coll <- checkmate::makeAssertCollection()
+    
     # errors for missing arguments
-    if (!is.null(missing)) {
-        for (varname in names(missing)) {
-            if (missing[[varname]]) {
-                ArgumentCheck::addError(paste("A value for ", varname,
-                    " was not provided", sep = "'"), Check)
+    if (!is.null(missing)){
+        for(varname in names(missing)){
+            if (missing[[varname]]){
+                coll$push(paste0("A value for ", varname, 
+                                 " was not provided", sep = "'"))
             }
         }
     }
 
     # errors for arguments outside of predefined options
-    if (!(is.null(match)) & !(is.null(acceptable))) {
+    if (!is.null(match) & !is.null(acceptable))){
         for (varname in names(match)) {
-            if (!(match[[varname]] %in% acceptable[[varname]]))
-                ArgumentCheck::addError(paste(NULL, varname, " must be one of ",
-                    paste(acceptable[[varname]], collapse = "', '"), NULL,
-                    sep = "'"), Check)
+            checkmate::assert_subset(x = match[[varname]], 
+                                     choices = acceptable[[varname]], 
+                                     .var.name = varname, 
+                                     add = coll)
         }
     }
 
-    # errors for NULL arguments
-    if (!is.null(null)) {
+    # error for NULL arguments
+    if (!is.null(null)){
         for (varname in names(null)) {
-            if (null[[varname]]) {
-                ArgumentCheck::addError(paste(NULL, varname,
-                    " must have non-NULL value", sep = "'"), Check)
+            if (null[[varname]]){
+                coll$push(paste(NULL, varname, " must have a non-NULL value",
+                                sep = "'"))
             }
         }
     }
 
-    return(Check)
+    return(coll)
 }
 
 

--- a/R/Impute.R
+++ b/R/Impute.R
@@ -180,7 +180,7 @@ ImputeNetwork <- function(data, net.coef = NULL,
     # Check arguments
     Check <- CreateArgCheck(match = list(type = type), acceptable =
                                 list(type = c("iteration", "pseudoinv")))
-    ArgumentCheck::finishArgCheck(Check)
+    checkmate::reportAssertions(Check)
 
     # Limit data and network to genes common to both
     arranged <- ArrangeData(data, net.coef)

--- a/R/Wrap.R
+++ b/R/Wrap.R
@@ -111,10 +111,11 @@ EvaluateMethods <- function(data, sce = NULL, do = c("Baseline", "DrImpute",
         DataCheck_SingleCellExperiment(sce)
         data <- SingleCellExperiment::normcounts(sce)
     }
+    
     Check <- CreateArgCheck(missing = list(data = missing(data)),
         match = list(type = type), acceptable = list(type = c("TPM", "count")),
         null = list(net.coef = is.null(net.coef), data = is.null(data)))
-    ArgumentCheck::finishArgCheck(Check)
+    checkmate::reportAssertions(Check)
     data <- DataCheck_Matrix(data)
     tr.length <- DataCheck_TrLength(tr.length)
 
@@ -292,7 +293,7 @@ Impute <- function(data, sce = NULL, do = "Ensemble", write = FALSE,
     check <- CreateArgCheck(missing = list(data = missing(data)),
         match = list(type = type), acceptable = list(type = c("TPM", "count")),
         null = list(net.coef = is.null(net.coef), data = is.null(data)))
-    ArgumentCheck::finishArgCheck(check)
+    checkmate::reportAssertions(check)
     CheckArguments_Impute(data, method.choice, do, tr.length, labels,
         cell.clusters, true.zero.thr, drop_thre)
     data <- DataCheck_Matrix(data); tr.length <- DataCheck_TrLength(tr.length)


### PR DESCRIPTION
Good morning, Dr Leote,

I recently received an e-mail from CRAN indicating that the `ArgumentCheck` package would be removed from CRAN unless certain changes were made prior to 17 May.  Unfortunately, I do not have the time available to perform continued maintenance on this package, especially since better packages exist to do this same function.  I recommend using the `checkmate` package instead, which as an active and responsive development group.  I've prepared this pull request that adjust your package to use `checkmate` instead.  Please consider this as an option, since `ArgumentCheck` will likely be taken of CRAN in the near future.

